### PR TITLE
Support for rport=<port no> in Via header

### DIFF
--- a/src/uri/domain.rs
+++ b/src/uri/domain.rs
@@ -46,6 +46,11 @@ use nom::{
     error::ParseError
 };
 
+pub fn parse_port<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8], Option<u16>, E> {
+    let (input, port) = opt(map_res::<_, _, _, _, E, _, _>(take_while::<_, _, E>(is_digit), parse_u16::<E>))(input)?;
+    Ok((input, port))
+}
+
 pub fn parse_domain<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8], Domain, E> {
   alt((parse_ip_domain::<E>, parse_domain_domain::<E>))(input)
 }
@@ -53,7 +58,7 @@ pub fn parse_domain<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a
 pub fn parse_ip_domain<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8], Domain, E> {
     let (input, addr) = parse_ip_address::<E>(input)?;
     let (input, _) = opt::<_, _, E, _>(char::<_, E>(':'))(input)?;
-    let (input, port) = opt(map_res::<_, _, _, _, E, _, _>(take_while::<_, _, E>(is_digit), parse_u16::<E>))(input)?;
+    let (input, port) = parse_port::<E>(input)?;
     Ok((input, Domain::Ipv4(addr, port)))
 }
 

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -18,7 +18,7 @@ pub mod schema;
 pub use self::schema::{parse_schema, UriSchema};
 
 pub mod domain;
-pub use self::domain::{parse_domain, Domain};
+pub use self::domain::{parse_domain, parse_port, Domain};
 
 pub mod params;
 pub use self::params::{parse_param, parse_params, UriParam};

--- a/tests/core/message.rs
+++ b/tests/core/message.rs
@@ -22,7 +22,7 @@ fn read_complex() {
     let remains = vec![];
     let uri = Uri::sip(domain!("example.com"))
                .auth(uri_auth!("user"))
-               .parameter(UriParam::RPort)
+               .parameter(UriParam::RPort(None))
                .parameter(UriParam::Other("new".into(), None))
                .parameter(UriParam::Other("Some".into(), Some("Param".into())))
                .parameter(UriParam::Other("Other".into(), None));

--- a/tests/headers/via.rs
+++ b/tests/headers/via.rs
@@ -35,8 +35,24 @@ fn read() {
         version: Version::default(),
         transport: Transport::Udp,
         uri: Uri::new_schemaless(ip_domain!(192, 168, 1, 120))
-            .parameter(UriParam::RPort)
+            .parameter(UriParam::RPort(None))
             .parameter(UriParam::Branch("z9hG4bK7Q6y313Qrt6Uc".into())),
+    };
+    assert_eq!(
+        Ok((remains.as_ref(), Header::Via(header))),
+        parse_via_header::<VerboseError<&[u8]>>(input)
+    );
+
+    let input = b"Via: SIP/2.0/UDP 192.168.1.1:5060;rport=5060;received=192.168.1.1;branch=8e7ec4e3d1e1380bc111f8723341ca70;transport=UDP\r\n";
+    let remains = vec!['\r' as u8, '\n' as u8];
+    let header = ViaHeader {
+        version: Version::default(),
+        transport: Transport::Udp,
+        uri: Uri::new_schemaless(ip_domain!(192, 168, 1, 1, 5060))
+            .parameter(UriParam::RPort(Some(5060)))
+            .parameter(UriParam::Received(ip_domain!(192, 168, 1, 1)))
+            .parameter(UriParam::Branch("8e7ec4e3d1e1380bc111f8723341ca70".into()))
+            .parameter(UriParam::Transport(Transport::Udp)),
     };
     assert_eq!(
         Ok((remains.as_ref(), Header::Via(header))),


### PR DESCRIPTION
see https://tools.ietf.org/html/rfc3581#section-4