### PR TITLE
derive Eq trait for Uri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "SIP protocol Implementation, with a focus towords softphone clien
 
 [dependencies]
 serde = { version = "1.0.107", features = ["derive"] }
-nom = "6.0.0-alpha1"
+nom = "=6.0.0-alpha1"
 rand = "0.7.3"
 sha = "1.0.3"
 md5 = "0.7.0"

--- a/src/core/transport.rs
+++ b/src/core/transport.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// SIP protocol transport.
-#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum Transport {
     Udp,
     Tcp,

--- a/src/uri/auth.rs
+++ b/src/uri/auth.rs
@@ -12,7 +12,7 @@ use nom::{
 use std::fmt;
 
 /// URI Credentials
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct UriAuth {
     pub username: String,
     pub password: Option<String>,

--- a/src/uri/domain.rs
+++ b/src/uri/domain.rs
@@ -7,7 +7,7 @@ use crate::parse::{parse_ip_address, parse_u16, slice_to_string};
 
 /// Domain address for a URI. Currently Only Ipv4 and
 /// domains are implemented.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum Domain {
     Ipv4(Ipv4Addr, Option<u16>),
     Domain(String, Option<u16>),

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -17,7 +17,7 @@ pub mod auth;
 pub use self::auth::{parse_uriauth, UriAuth};
 
 /// Universal Rescource Identifier for libsip.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Uri {
     pub schema: Option<UriSchema>,
     pub host: Domain,

--- a/src/uri/params.rs
+++ b/src/uri/params.rs
@@ -19,7 +19,7 @@ use nom::{
 /// Uri Parameters.
 ///
 /// TODO: Expand this enum. Similar to `libsip::Header`
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum UriParam {
     Transport(Transport),
     Branch(String),

--- a/src/uri/schema.rs
+++ b/src/uri/schema.rs
@@ -4,7 +4,7 @@ use nom::{branch::alt, bytes::complete::tag_no_case, combinator::map, error::Par
 use std::fmt;
 
 /// Sip URI Schema.
-#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum UriSchema {
     Sip,
     Sips,


### PR DESCRIPTION
Derives Equality trait for Uri and its components (UriAuth, UriSchema, Transport, Domain, UriParam).

That's quite handy to have (especially when writing tests) for a small compilation cost.